### PR TITLE
Add Passwords & Multiple Config Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains scripts for the R&D setup of OpenFlight Compute.
 
-## How to Use It
+## Configure Environment
 
 Currently, this is being developed and tested on Azure.
 
@@ -23,18 +23,59 @@ Currently, this is being developed and tested on Azure.
     bash setup.sh
     ```
 
-5. Update the config variables to reflect cloud configuration
+5. Update the config variables to reflect desired cloud configuration
 
    ```
-   vim config.sh
+   vim configs/default.sh
    ```
 
-5. Create a cluster
+## Create a Cluster
+
+### Cluster Using Default Configuration
+
+- Navigate to builder directory
 
     ```
     cd openflight-compute-cluster-builder
+    ```
+
+- Create a cluster, providing the name and public SSH key to use
+
+    ```
     bash build-cluster.sh CLUSTERNAME 'SSH PUBLIC KEY'
     ```
+
+### Cluster Using Alternative Configuration
+
+In some circumstances there are common deployment configurations that make constant management of one config file time-consuming and inflexible. For this reason, multiple configuration files can exist within `configs/` to allow for storage of these deployment details.
+
+- Navigate to builder directory
+
+    ```
+    cd openflight-compute-cluster-builder
+    ```
+
+- Create a new config file
+
+    ```
+    cp configs/default.sh configs/mynewdeploymentconfig.sh
+    ```
+
+- Update variables and configuration to meet your requirements
+
+   ```
+   vim configs/mynewdeploymentconfig.sh
+   ```
+
+- Create a cluster, providing the name and public SSH key to use
+
+    ```
+    CONFIG=mynewdeploymentconfig bash build-cluster.sh CLUSTERNAME 'SSH PUBLIC KEY'
+    ```
+
+### Additional Notes
+
+- If the variable `SSH_PUB_KEY` is present in a config file then it will be used. This value *will be overwritten if an SSH key is passed on the command line*.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,16 @@ In some circumstances there are common deployment configurations that make const
     CONFIG=mynewdeploymentconfig bash build-cluster.sh CLUSTERNAME 'SSH PUBLIC KEY'
     ```
 
+### Cluster Using Password Instead of SSH Key
+
+While less secure, this method of authorising access to a cluster may be required from time to time. In order to switch from key authorisation to password, set the `AUTH` variable to `password` in the desired config file.
+
+When `AUTH` is set to `password` the second argument to the build script will be used as the password instead of being used as an SSH public key.
+
 ### Additional Notes
 
 - If the variable `SSH_PUB_KEY` is present in a config file then it will be used. This value *will be overwritten if an SSH key is passed on the command line*.
+- If the variable `PASSWORD` is present in a config file then it will be used. This value *will be overwritten if a password is passed on the command line*.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ When `AUTH` is set to `password` the second argument to the build script will be
 
 ### Additional Notes
 
-- If the variable `SSH_PUB_KEY` is present in a config file then it will be used. This value *will be overwritten if an SSH key is passed on the command line*.
-- If the variable `PASSWORD` is present in a config file then it will be used. This value *will be overwritten if a password is passed on the command line*.
+- If the variable `SSH_PUB_KEY` is present in a config file then it will be used. *This value will be overwritten if an SSH key is passed on the command line*.
+- If the variable `PASSWORD` is present in a config file then it will be used. *This value will be overwritten if a password is passed on the command line*.
 
 ## Versioning
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -151,8 +151,7 @@ function deploy_azure() {
     az group create --name "$CLUSTERNAME" --location "$AZURE_LOCATION"
     az group deployment create --name "$CLUSTERNAME" --resource-group "$CLUSTERNAME" \
         --template-file $DIR/templates/azure/cluster.json \
-        --parameters sshPublicKey="$SSH_PUB_KEY" \
-        sourceimage="$AZURE_SOURCEIMAGE" \
+        --parameters sourceimage="$AZURE_SOURCEIMAGE" \
         clustername="$CLUSTERNAMEARG" \
         computeNodesCount="$COMPUTENODES" \
         customdata="$CUSTOMDATA"
@@ -200,8 +199,7 @@ function deploy_aws() {
     # Deploy resources
     aws cloudformation deploy --template-file $DIR/templates/aws/cluster.yaml --stack-name $CLUSTERNAME \
         --region "$AWS_LOCATION" \
-        --parameter-overrides sshPublicKey="$SSH_PUB_KEY" \
-        sourceimage="$AWS_SOURCEIMAGE" \
+        --parameter-overrides sourceimage="$AWS_SOURCEIMAGE" \
         clustername="$CLUSTERNAMEARG" \
         computeNodesCount="$COMPUTENODES" \
         customdata="$CUSTOMDATA"

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -34,8 +34,6 @@ LOG="$DIR/log/deploy.log"
 SEED=$(head /dev/urandom | tr -dc a-z0-9 | head -c 6 ; echo '')
 CLUSTERNAME="$CLUSTERNAMEARG-$SEED"
 
-# The host IP which is sharing setup.sh script at http://IP/deployment/setup.sh
-CONTROLLERIP=$(dig +short myip.opendns.com @resolver1.opendns.com)
 GATEWAYIP="Unknown"
 
 #################
@@ -50,11 +48,6 @@ elif [ "$COMPUTENODES" -lt 2 -o "$COMPUTENODES" -gt 8 ] ; then
     echo "Number of nodes must be between 2 and 8"
     exit 1
 fi
-
-###############
-# Log Details #
-###############
-echo "$(date +'%Y-%m-%d %H-%M-%S') | $CLUSTERNAME | Start Deploy | $PLATFORM | $SSH_PUB_KEY" |tee -a $LOG
 
 #############
 # Functions #
@@ -238,6 +231,8 @@ case $AUTH in
         exit 1
     ;;
 esac
+
+echo "$(date +'%Y-%m-%d %H-%M-%S') | $CLUSTERNAME | Start Deploy | $PLATFORM | Auth Method: $AUTH" |tee -a $LOG
 
 generate_custom_data
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -13,7 +13,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Source variables
 if [ -z "${CONFIG}" ] ; then
-    source $DIR/configs/config.sh
+    source $DIR/configs/default.sh
 else
     config_path=$DIR/configs/$CONFIG.sh
     if [ -f $config_path ] ; then

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -12,10 +12,21 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Source variables
-source $DIR/config.sh
+if [ -z "${CONFIG}" ] ; then
+    source $DIR/configs/config.sh
+else
+    config_path=$DIR/configs/$CONFIG.sh
+    if [ -f $config_path ] ; then
+        source $config_path
+    else
+        echo "Error loading $CONFIG"
+        echo "Could not load $config_path"
+        exit 1
+    fi
+fi
 
 CLUSTERNAMEARG="$1"
-SSH_PUB_KEY="$2"
+SSH_PUB_KEY="${2:-$SSH_PUB_KEY}"
 
 LOG="$DIR/log/deploy.log"
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -98,6 +98,8 @@ $(if [[ "$AUTH" == "key" ]] ; then
 echo "  - echo "$SSH_PUB_KEY" >> /home/flight/.ssh/authorized_keys"
 else
 echo "  - echo "$PASSWORD" | passwd --stdin flight"
+echo "  - sed 's/[\^|#]?PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
+echo "  - systemctl restart sshd"
 fi)
   - firewall-cmd --remove-interface eth0 --zone public --permanent && firewall-cmd --add-interface eth0 --zone trusted --permanent && firewall-cmd --reload
   - timedatectl set-timezone Europe/London

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -98,7 +98,7 @@ $(if [[ "$AUTH" == "key" ]] ; then
 echo "  - echo "$SSH_PUB_KEY" >> /home/flight/.ssh/authorized_keys"
 else
 echo "  - echo "$PASSWORD" | passwd --stdin flight"
-echo "  - sed 's/[\^|#]?PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
+echo "  - sed -i 's/[\^|#]?PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
 echo "  - systemctl restart sshd"
 fi)
   - firewall-cmd --remove-interface eth0 --zone public --permanent && firewall-cmd --add-interface eth0 --zone trusted --permanent && firewall-cmd --reload

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -60,7 +60,7 @@ function check_key() {
         exit 1
     fi
 
-    if echo "$SSH_PUB_KEY" | ssh-keygen -lf /dev/stdin > /dev/null 2>&1 ; then
+    if ! echo "$SSH_PUB_KEY" | ssh-keygen -lf /dev/stdin > /dev/null 2>&1 ; then
         echo "Invalid SSH key"
         echo "  The SSH key provided was not successfully validated by ssh-keygen"
         echo "  It is most likely that a character or symbol is missing from the key"

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -98,7 +98,7 @@ $(if [[ "$AUTH" == "key" ]] ; then
 echo "  - echo "$SSH_PUB_KEY" >> /home/flight/.ssh/authorized_keys"
 else
 echo "  - echo "$PASSWORD" | passwd --stdin flight"
-echo "  - sed -i 's/[\^|#]?PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
+echo "  - sed -i 's/^PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
 echo "  - systemctl restart sshd"
 fi)
   - firewall-cmd --remove-interface eth0 --zone public --permanent && firewall-cmd --add-interface eth0 --zone trusted --permanent && firewall-cmd --reload

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -51,20 +51,6 @@ elif [ "$COMPUTENODES" -lt 2 -o "$COMPUTENODES" -gt 8 ] ; then
     exit 1
 fi
 
-case $AUTH in 
-    "key")
-        check_key
-    ;;
-    "password")
-        check_password
-    ;;
-    *)
-        echo "Unrecognised auth type ($AUTH)"
-        echo "Set to either 'key' or 'password'"
-        exit 1
-    ;;
-esac
-
 ###############
 # Log Details #
 ###############
@@ -238,6 +224,20 @@ function run_ansible() {
 #################
 # Run Functions #
 #################
+
+case $AUTH in 
+    "key")
+        check_key
+    ;;
+    "password")
+        check_password
+    ;;
+    *)
+        echo "Unrecognised auth type ($AUTH)"
+        echo "Set to either 'key' or 'password'"
+        exit 1
+    ;;
+esac
 
 generate_custom_data
 

--- a/configs/default.sh
+++ b/configs/default.sh
@@ -9,6 +9,12 @@ PLATFORM="azure"
 # A value between 2 and 8
 COMPUTENODES="2"
 
+# Public SSH key for user access
+## Note: This will be overwritten if an SSH key is given
+## on the CLI
+#SSH_PUB_KEY=""
+
+
 # If true then the ansible-playbook will run additional
 # configuration steps for the flight environment to ensure
 # dependencies for the desktop and software environments

--- a/configs/default.sh
+++ b/configs/default.sh
@@ -9,11 +9,28 @@ PLATFORM="azure"
 # A value between 2 and 8
 COMPUTENODES="2"
 
+
+#
+# Authorisation
+#
+
+# Either 'key' or 'password'
+AUTH="key"
+
 # Public SSH key for user access
 ## Note: This will be overwritten if an SSH key is given
 ## on the CLI
 #SSH_PUB_KEY=""
 
+# Password for user access
+## Note: This will only be used if the AUTH var is set to
+## password
+#PASSWORD=""
+
+
+#
+# Flight Env Bootstrap
+#
 
 # If true then the ansible-playbook will run additional
 # configuration steps for the flight environment to ensure

--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -8,7 +8,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Source variables
-source $DIR/config.sh
+source $DIR/configs/config.sh
 
 CLUSTERS="$(ls /opt/flight/clusters/)"
 CLUSTERNAME="$1"

--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -8,7 +8,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Source variables
-source $DIR/configs/config.sh
+source $DIR/configs/default.sh
 
 CLUSTERS="$(ls /opt/flight/clusters/)"
 CLUSTERNAME="$1"

--- a/destroy_cluster.sh
+++ b/destroy_cluster.sh
@@ -8,7 +8,18 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Source variables
-source $DIR/configs/default.sh
+if [ -z "${CONFIG}" ] ; then
+    source $DIR/configs/default.sh
+else
+    config_path=$DIR/configs/$CONFIG.sh
+    if [ -f $config_path ] ; then
+        source $config_path
+    else
+        echo "Error loading $CONFIG"
+        echo "Could not load $config_path"
+        exit 1
+    fi
+fi
 
 CLUSTERS="$(ls /opt/flight/clusters/)"
 CLUSTERNAME="$1"
@@ -26,6 +37,9 @@ function destroy_cluster {
         "azure")
             destroy_cluster_azure $cluster
             ;;
+        "aws")
+            destroy_cluster_aws $cluster
+            ;;
         *)
             echo "Unrecognised platform, check config.sh"
             exit 1
@@ -37,6 +51,11 @@ function destroy_cluster {
 function destroy_cluster_azure {
     cluster=$1
     az group delete --name $cluster
+}
+
+function destroy_cluster_aws {
+    cluster=$1
+    aws cloudformation delete-stack --stack-name $cluster --region $AWS_REGION
 }
 
 #################

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -149,7 +149,7 @@
             "id": "[parameters('sourceimage')]"
           }
         },
-            "osProfile": {
+        "osProfile": {
           "computerName": "[concat('gateway1.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
           "customdata": "[parameters('customdata')]",
@@ -157,7 +157,6 @@
             "disablePasswordAuthentication": true
             }
           }
-        },
         "networkProfile": {
           "networkInterfaces": [
           {
@@ -252,7 +251,6 @@
             "disablePasswordAuthentication": true
             }
           }
-        },
         "networkProfile": {
           "networkInterfaces": [
           {

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -155,10 +155,17 @@
           "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": true
-
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "/tmp/placeholder-ssh",
+                        "keyData": "this key created to prevent azure template from erroring"
+                    }
+                ]
             }
-          },
+          }
+        },
         "networkProfile": {
           "networkInterfaces": [
           {
@@ -252,9 +259,17 @@
           "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": true
+            "disablePasswordAuthentication": true,
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "path": "/tmp/placeholder-ssh",
+                        "keyData": "this key created to prevent azure template from erroring"
+                    }
+                ]
             }
-          },
+          }
+        },
         "networkProfile": {
           "networkInterfaces": [
           {

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -167,7 +167,6 @@
                 }
           }
           ]
-        }
       },
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkInterfaces', 'flightcloudclustergateway1network1interface')]"
@@ -263,7 +262,6 @@
                 }
           }
           ]
-        }
       },
       "dependsOn": [
         "nicLoop"

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -160,7 +160,7 @@
                 "publicKeys": [
                     {
                         "path": "/home/flight/.ssh/authorized_keys",
-                        "keyData": "this-key-created-to-prevent-azure-template-from-erroring"
+                        "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd"
                     }
                 ]
             }
@@ -264,7 +264,7 @@
                 "publicKeys": [
                     {
                         "path": "/home/flight/.ssh/authorized_keys",
-                        "keyData": "this-key-created-to-prevent-azure-template-from-erroring"
+                        "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/0R5EvmSrySy2I+8Cx6eOX7cVuYFXx5D0O1x0+OmAZ0Qaj9d7E0Nj4ZcWxdCT03uFl1Ka4tInDlQmMyy0V1/AftpHxBEnB17Pk/lJnDW1YstmAqD0GlFa1CrxUdtHd+jB3LJmdoHsV6fRGpMOgFd+u/4Wces7KAqYFmL5uPG1UTCMgokQ2qboQgEVspXotMvni1iil3kEjyH/eW64Laxmn2Vxls9feZ1o95mPQhJPJcN7MMo1h+jkxyat3bawtpqyV7fXYU0+BO2JHpu/VIEDHtxhlk7RhI0U06XbJu6ZCCUrEX8idIhw4hueQpKwVYplTXssa9JqNlcjouqLj5kd"
                     }
                 ]
             }

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -156,7 +156,7 @@
           "linuxConfiguration": {
             "disablePasswordAuthentication": true
             }
-          }
+          },
         "networkProfile": {
           "networkInterfaces": [
           {
@@ -166,6 +166,7 @@
                 }
           }
           ]
+        }
       },
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkInterfaces', 'flightcloudclustergateway1network1interface')]"
@@ -250,7 +251,7 @@
           "linuxConfiguration": {
             "disablePasswordAuthentication": true
             }
-          }
+          },
         "networkProfile": {
           "networkInterfaces": [
           {
@@ -265,8 +266,6 @@
         "nicLoop"
       ]
     }
+    }
   ]
 }
-
-
-

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -279,11 +279,11 @@
                 }
           }
           ]
-      },
-      "dependsOn": [
+      }
+    },
+    "dependsOn": [
         "nicLoop"
       ]
-    }
     }
   ]
 }

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -159,8 +159,8 @@
             "ssh": {
                 "publicKeys": [
                     {
-                        "path": "/tmp/placeholder-ssh",
-                        "keyData": "this key created to prevent azure template from erroring"
+                        "path": "/home/flight/.ssh/authorized_keys",
+                        "keyData": "this-key-created-to-prevent-azure-template-from-erroring"
                     }
                 ]
             }
@@ -263,8 +263,8 @@
             "ssh": {
                 "publicKeys": [
                     {
-                        "path": "/tmp/placeholder-ssh",
-                        "keyData": "this key created to prevent azure template from erroring"
+                        "path": "/home/flight/.ssh/authorized_keys",
+                        "keyData": "this-key-created-to-prevent-azure-template-from-erroring"
                     }
                 ]
             }

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -2,12 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-      "sshPublicKey": {
-          "type": "string",
-          "metadata": {
-              "description": "SSH public key for flight user"
-          }
-      },
       "sourceimage": {
           "type": "string",
           "metadata": {
@@ -160,12 +154,7 @@
           "adminUsername": "flight",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": true,
-            "ssh": {
-            "publicKeys": [{
-              "path": "[concat ('/home/flight', '/.ssh/authorized_keys')]",
-              "keyData": "[parameters('sshPublicKey')]"
-              }]
+            "disablePasswordAuthentication": true
             }
           }
         },
@@ -261,12 +250,7 @@
           "adminUsername": "flight",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": true,
-            "ssh": {
-            "publicKeys": [{
-              "path": "[concat ('/home/flight', '/.ssh/authorized_keys')]",
-              "keyData": "[parameters('sshPublicKey')]"
-              }]
+            "disablePasswordAuthentication": true
             }
           }
         },

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -152,9 +152,11 @@
         "osProfile": {
           "computerName": "[concat('gateway1.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
+          "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true
+
             }
           },
         "networkProfile": {
@@ -247,6 +249,7 @@
           "osProfile": {
           "computerName": "[concat('node0', copyindex(1), '.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
+          "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdata')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true


### PR DESCRIPTION
This PR adds:
- Option to change authorisation from public key to password (with adaptations to Azure template to support this)
- Allow for multiple config files (optional variable that redirects where the script gets it config from)
- Add variable handling to allow setting key/password in config and additionally overriding that key/password on runs using that config
- Add AWS & multi-config support to the destroy_cluster script