### PR TITLE
Check Clusters Up & Delete Volumes on Destroy (AWS)

### DIFF
--- a/check-clusters.sh
+++ b/check-clusters.sh
@@ -16,13 +16,13 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 function check_up {
     IP=$(grep '^gateway1' /opt/flight/clusters/$cluster |sed 's/.*ansible_host=//g')
-    echo "Gateway IP for $cluster is $IP"
-    if ! nmap $IP -PN -p ssh ; then
+    if ! ssh -q -o ConnectTimeout=1 -o ConnectionAttempts=1 $IP exit > /dev/null; then
         echo "Cannot connect to $IP for SSH, presuming destroyed"
+        rm -f /opt/flight/clusters/$cluster
     fi
 }
 
-for cluster in $(ls /opt/flight/clusters) ; do 
+for cluster in $(ls /opt/flight/clusters) ; do
     echo "Checking if $cluster gateway1 is up/reachable"
     check_up
 done

--- a/check-clusters.sh
+++ b/check-clusters.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Use this script to check the contents of /opt/flight/clusters
+# and remove any clusters that are no longer up/reachable (by SSH).
+#
+
+# Install nmap if not present
+if ! rpm -qa |grep -q nmap ; then
+    echo "Installing nmap"
+    yum install -y nmap
+fi
+
+# Get directory of script for locating templates and config
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+function check_up {
+    IP=$(grep '^gateway1' /opt/flight/clusters/$cluster |sed 's/.*ansible_host=//g')
+    echo "Gateway IP for $cluster is $IP"
+    if ! nmap $IP -PN -p ssh ; then
+        echo "Cannot connect to $IP for SSH, presuming destroyed"
+    fi
+}
+
+for cluster in $(ls /opt/flight/clusters) ; do 
+    echo "Checking if $cluster gateway1 is up/reachable"
+    check_up
+done

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -302,6 +302,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclustergateway1pubIP: 
     Type: AWS::EC2::EIP
@@ -336,6 +340,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode01pubIP:
     Type: AWS::EC2::EIP
@@ -370,6 +378,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode02pubIP:
     Type: AWS::EC2::EIP
@@ -406,6 +418,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode03pubIP:
     Type: AWS::EC2::EIP
@@ -444,6 +460,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode04pubIP:
     Type: AWS::EC2::EIP
@@ -482,6 +502,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode05pubIP:
     Type: AWS::EC2::EIP
@@ -520,6 +544,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode06pubIP:
     Type: AWS::EC2::EIP
@@ -558,6 +586,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode07pubIP:
     Type: AWS::EC2::EIP
@@ -596,6 +628,10 @@ Resources:
           NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
           DeviceIndex: 0
       UserData: !Ref customdata
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            DeleteOnTermination: 'true'
 
   flightcloudclusternode08pubIP:
     Type: AWS::EC2::EIP


### PR DESCRIPTION
This PR provides a script that lazily identifies which of the clusters in `/opt/flight/clusters/` are still alive, removing those that aren't. It also contains modifications to the AWS template to ensure that the system disk for every node is deleted when the cloudformation stack is terminated.