### PR TITLE
Better Separation of Platform and Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ When `AUTH` is set to `password` the second argument to the build script will be
 - If the variable `SSH_PUB_KEY` is present in a config file then it will be used. *This value will be overwritten if an SSH key is passed on the command line*.
 - If the variable `PASSWORD` is present in a config file then it will be used. *This value will be overwritten if a password is passed on the command line*.
 
+## Cloud Init
+
+The `build-cluster.sh` script creates a cloud-init string that will be run on all the nodes, the cloud-init config:
+- Adds the build machine's SSH public key to all nodes (for passwordless remote access, required for running of ansible playbook)
+- Sets up configured SSH public key/password access (depending on config) 
+- Disables the firewall
+- Disabled NetworkManager
+- Sets the timezone to Europe/London
+- Ensures that the cluster domain name is part of the search zone in `/etc/resolv.conf`
+
 ## Versioning
 
 The version release tags align with the tags in the openflight-ansible-playbook tags.

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -224,11 +224,10 @@ function set_hostnames() {
         name=$(echo "$node" |awk '{print $1}')
         ip=$(echo "$node" |awk '{print $2}' |sed 's/.*ansible_host=//g')
 
-        until ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $ip exit 2>/dev/null ; do
-            echo "Waiting for $name to be reachable"
+        until ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $ip exit </dev/null 2>/dev/null ; do
             sleep 5
         done
-        ssh $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local"
+        ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local" </dev/null
     done <<< "$(echo "$NODES")"
 }
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -224,6 +224,10 @@ function set_hostnames() {
         name=$(echo "$node" |awk '{print $1}')
         ip=$(echo "$node" |awk '{print $2}' |sed 's/.*ansible_host=//g')
 
+        until ssh $ip exit ; do
+            echo "Waiting for $name to be reachable"
+            sleep 5
+        done
         ssh $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local"
     done <<< "$(echo "$NODES")"
 }

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -224,7 +224,7 @@ function set_hostnames() {
         name=$(echo "$node" |awk '{print $1}')
         ip=$(echo "$node" |awk '{print $2}' |sed 's/.*ansible_host=//g')
 
-        until ssh $ip exit ; do
+        until ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $ip exit 2>/dev/null ; do
             echo "Waiting for $name to be reachable"
             sleep 5
         done

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -101,7 +101,8 @@ echo "  - echo "$PASSWORD" | passwd --stdin flight"
 echo "  - sed -i 's/^PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config"
 echo "  - systemctl restart sshd"
 fi)
-  - firewall-cmd --remove-interface eth0 --zone public --permanent && firewall-cmd --add-interface eth0 --zone trusted --permanent && firewall-cmd --reload
+  - systemctl disable firewalld && systemctl stop firewalld
+  - systemctl disable NetworkManager && systemctl stop NetworkManager
   - timedatectl set-timezone Europe/London
   - grep -q "$CLUSTERNAME" /etc/resolv.conf || sed -r 's/^search (.*?)( pri.$CLUSTERNAME.cluster.local|$)/search \1 pri.$CLUSTERNAME.cluster.local/' /etc/resolv.conf
 EOF

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -157,7 +157,7 @@ done)
 EOF
     
     # Customise nodes
-    run_ansible
+    run_customisation
 }
 
 function check_aws() {
@@ -208,7 +208,24 @@ done)
 EOF
 
     # Customise nodes
+    run_customisation
+}
+
+function run_customisation() {
+    set_hostnames
     run_ansible
+}
+
+function set_hostnames() {
+    NODES=$(grep -vE '^\[|^$' /opt/flight/clusters/$CLUSTERNAME)
+
+    # Loop through nodes and set hostname
+    while IFS= read -r node ; do
+        name=$(echo "$node" |awk '{print $1}')
+        ip=$(echo "$node" |awk '{print $2}' |sed 's/.*ansible_host=//g')
+
+        ssh $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local"
+    done <<< "$(echo "$NODES")"
 }
 
 function run_ansible() {

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -103,6 +103,7 @@ echo "  - systemctl restart sshd"
 fi)
   - firewall-cmd --remove-interface eth0 --zone public --permanent && firewall-cmd --add-interface eth0 --zone trusted --permanent && firewall-cmd --reload
   - timedatectl set-timezone Europe/London
+  - grep -q "$CLUSTERNAME" /etc/resolv.conf || sed -r 's/^search (.*?)( pri.$CLUSTERNAME.cluster.local|$)/search \1 pri.$CLUSTERNAME.cluster.local/' /etc/resolv.conf
 EOF
 )
     CUSTOMDATA=$(echo "$DATA" |base64 -w 0)

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -104,7 +104,7 @@ fi)
   - systemctl disable firewalld && systemctl stop firewalld
   - systemctl disable NetworkManager && systemctl stop NetworkManager
   - timedatectl set-timezone Europe/London
-  - grep -q "$CLUSTERNAME" /etc/resolv.conf || sed -r 's/^search (.*?)( pri.$CLUSTERNAME.cluster.local|$)/search \1 pri.$CLUSTERNAME.cluster.local/' /etc/resolv.conf
+  - grep -q "$CLUSTERNAMEARG" /etc/resolv.conf || sed -r 's/^search (.*?)( pri.$CLUSTERNAMEARG.cluster.local|$)/search \1 pri.$CLUSTERNAMEARG.cluster.local/' /etc/resolv.conf
 EOF
 )
     CUSTOMDATA=$(echo "$DATA" |base64 -w 0)

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -104,7 +104,7 @@ fi)
   - systemctl disable firewalld && systemctl stop firewalld
   - systemctl disable NetworkManager && systemctl stop NetworkManager
   - timedatectl set-timezone Europe/London
-  - grep -q "$CLUSTERNAMEARG" /etc/resolv.conf || sed -r 's/^search (.*?)( pri.$CLUSTERNAMEARG.cluster.local|$)/search \1 pri.$CLUSTERNAMEARG.cluster.local/' /etc/resolv.conf
+  - grep -q "$CLUSTERNAMEARG" /etc/resolv.conf || sed -ri 's/^search (.*?)( pri.$CLUSTERNAMEARG.cluster.local|$)/search \1 pri.$CLUSTERNAMEARG.cluster.local/' /etc/resolv.conf
 EOF
 )
     CUSTOMDATA=$(echo "$DATA" |base64 -w 0)


### PR DESCRIPTION
It has been recognised that the waters between platform and stack had become muddied, this PR (and one soon to go up in the openflight-ansible-playbook) addresses this by bringing various network operations/tweaks into the build script instead of doing it through the playbook:

- Setup `resolv.conf` search domain in `cloud-init`
- Disable/stop both firewalld and NetworkManager in `cloud-init` 
- Set node hostnames via ssh before running the playbook