### PR TITLE
Cloud Cost Suite Compatibility & Network Infrastructure Improvements

### DIFF
--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -274,7 +274,7 @@ function run_ansible() {
     # Run ansible playbook
     cd $ANSIBLE_PLAYBOOK_DIR
     export ANSIBLE_HOST_KEY_CHECKING=false
-    ARGS="cluster_name=$CLUSTERNAMEARG munge_key=$( (head /dev/urandom | tr -dc a-z0-9 | head -c 18 ; echo '') | sha512sum | cut -d' ' -f1) compute_nodes=node[01-0$COMPUTENODES] $flightenv_dev_var $flightenv_bootstrap_var"
+    ARGS="cluster_name=$CLUSTERNAMEARG munge_key=$( (head /dev/urandom | tr -dc a-z0-9 | head -c 18 ; echo '') | sha512sum | cut -d' ' -f1) compute_nodes=cnode[01-0$COMPUTENODES] $flightenv_dev_var $flightenv_bootstrap_var"
     echo "$(date +'%Y-%m-%d %H-%M-%S') | $CLUSTERNAME | Start Ansible | ansible-playbook -i /opt/flight/clusters/$CLUSTERNAME --extra-vars \"$ARGS\" openflight.yml" |tee -a $LOG
     ansible-playbook -i /opt/flight/clusters/$CLUSTERNAME --extra-vars "$ARGS" openflight.yml
 }

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -126,6 +126,7 @@ $(echo "$DATA")
   - grep -q "PEERDNS" /etc/sysconfig/network-scripts/ifcfg-eth0 && sed -i 's/PEERDNS=*/PEERDNS=yes/g' /etc/sysconfig/network-scripts/ifcfg-eth0 || echo "PEERDNS=yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0 
   - grep -q "PEERROUTES" /etc/sysconfig/network-scripts/ifcfg-eth0 && sed -i 's/PEERROUTES=*/PEERROUTES=no/g' /etc/sysconfig/network-scripts/ifcfg-eth0 || echo "PEERROUTES=no" >> /etc/sysconfig/network-scripts/ifcfg-eth0 
   - systemctl restart network
+  - grep -q "$CLUSTERNAMEARG" /etc/resolv.conf || sed -ri 's/^search (.*?)( pri.$CLUSTERNAMEARG.cluster.local|$)/search \1 pri.$CLUSTERNAMEARG.cluster.local/' /etc/resolv.conf
 EOF
 )
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -177,7 +177,7 @@ gateway1    ansible_host=$GATEWAYIP
 
 [nodes]
 $(i=1 ; while [ $i -le $COMPUTENODES ] ; do
-echo "node0$i    ansible_host=$(az network public-ip show -g $CLUSTERNAME -n flightcloudclusternode0$i\pubIP --query '{address: ipAddress}' --output yaml |awk '{print $2}')"
+echo "node0$i    ansible_host=$(az vm list-ip-addresses -g $CLUSTERNAME -n flightcloudclusternode0$i --query [?virtualMachine].virtualMachine.network.privateIpAddresses --output tsv) ansible_ssh_common_args='-J $GATEWAYIP'"
 i=$((i + 1))
 done)
 EOF

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -252,10 +252,10 @@ function set_hostnames() {
         ip=$(echo "$node" |awk '{print $2}' |sed 's/.*ansible_host=//g')
         ssh_args=$(echo "$node" |awk '{print $3,$4}' |sed "s/.*ansible_ssh_common_args=//g;s/'//g")
 
-        until ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no $ssh_args $ip exit </dev/null 2>/dev/null ; do
+        until ssh -q -o StrictHostKeyChecking=no -o PasswordAuthentication=no $ssh_args $ip exit </dev/null 2>/dev/null ; do
             sleep 5
         done
-        ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PasswordAuthentication=no $ssh_args $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local" </dev/null
+        ssh -q -o StrictHostKeyChecking=no -o PasswordAuthentication=no $ssh_args $ip "hostnamectl set-hostname $name.pri.$CLUSTERNAMEARG.cluster.local" </dev/null
     done <<< "$(echo "$NODES")"
 }
 

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -228,7 +228,7 @@ gateway1    ansible_host=$GATEWAYIP
 
 [nodes]
 $(i=1 ; while [ $i -le $COMPUTENODES ] ; do
-echo "node0$i    ansible_host=$(aws ec2 describe-instances --instance-ids $(aws cloudformation describe-stack-resources --region "eu-west-2" --stack-name ben2-ikvt04 --logical-resource-id flightcloudclusternode01 --query 'StackResources[].PhysicalResourceId' --output text) --query 'Reservations[*].Instances[*].[PrivateIpAddress]' --output text) ansible_ssh_common_args='-J $GATEWAYIP'"
+echo "node0$i    ansible_host=$(aws ec2 describe-instances --instance-ids $(aws cloudformation describe-stack-resources --region "eu-west-2" --stack-name $CLUSTERNAME --logical-resource-id flightcloudclusternode0$i --query 'StackResources[].PhysicalResourceId' --output text) --query 'Reservations[*].Instances[*].[PrivateIpAddress]' --output text) ansible_ssh_common_args='-J $GATEWAYIP'"
 i=$((i + 1))
 done)
 EOF

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -228,7 +228,7 @@ gateway1    ansible_host=$GATEWAYIP
 
 [nodes]
 $(i=1 ; while [ $i -le $COMPUTENODES ] ; do
-echo "node0$i    ansible_host=$(aws ec2 describe-instances --instance-ids $(aws cloudformation describe-stack-resources --region "eu-west-2" --stack-name $CLUSTERNAME --logical-resource-id flightcloudclusternode0$i --query 'StackResources[].PhysicalResourceId' --output text) --query 'Reservations[*].Instances[*].[PrivateIpAddress]' --output text) ansible_ssh_common_args='-J $GATEWAYIP'"
+echo "node0$i    ansible_host=$(aws ec2 describe-instances --region "$AWS_LOCATION" --instance-ids $(aws cloudformation describe-stack-resources --region "$AWS_LOCATION" --stack-name $CLUSTERNAME --logical-resource-id flightcloudclusternode0$i --query 'StackResources[].PhysicalResourceId' --output text) --query 'Reservations[*].Instances[*].[PrivateIpAddress]' --output text) ansible_ssh_common_args='-J $GATEWAYIP'"
 i=$((i + 1))
 done)
 EOF

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -112,6 +112,7 @@ EOF
     GW=$(cat << EOF
 $(echo "$DATA")
   - firewall-cmd --add-rich-rule='rule family="ipv4" source address="10.10.0.0/255.255.0.0" masquerade' --permanent
+  - firewall-cmd --set-target=ACCEPT --permanent
   - firewall-cmd --reload
   - echo "net.ipv4.ip_forward = 1" > /etc/sysctl.conf
   - echo 1 > /proc/sys/net/ipv4/ip_forward

--- a/check-clusters.sh
+++ b/check-clusters.sh
@@ -15,7 +15,7 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 function check_up {
-    IP=$(grep '^gateway1' /opt/flight/clusters/$cluster |sed 's/.*ansible_host=//g')
+    IP=$(grep '^chead1' /opt/flight/clusters/$cluster |sed 's/.*ansible_host=//g')
     if ! ssh -q -o ConnectTimeout=1 -o ConnectionAttempts=1 $IP exit > /dev/null; then
         echo "Cannot connect to $IP for SSH, presuming destroyed"
         rm -f /opt/flight/clusters/$cluster
@@ -23,6 +23,6 @@ function check_up {
 }
 
 for cluster in $(ls /opt/flight/clusters) ; do
-    echo "Checking if $cluster gateway1 is up/reachable"
+    echo "Checking if $cluster chead1 is up/reachable"
     check_up
 done

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -98,13 +98,6 @@ Resources:
     Properties:
       SubnetId: !Ref flightcloudclusternetwork1
       RouteTableId: !Ref flightcloudclusterroutetable
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   flightcloudclusterrouteinternetgateway:
     Type: AWS::EC2::Route

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -106,13 +106,6 @@ Resources:
       RouteTableId: !Ref flightcloudclusterroutetable
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref flightcloudclusterinternetgateway
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   flightcloudclustersecuritygroup:
     Type: AWS::EC2::SecurityGroup

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -7,9 +7,12 @@ Parameters:
   clustername:
     Type: String
     Description: 'Name of the cluster'
-  customdata:
+  customdatagw:
     Type: String
-    Description: 'Cloud-init customdata for all systems encoded in base64'
+    Description: 'Cloud-init customdata for gateway encoded in base64'
+  customdatanode:
+    Type: String
+    Description: 'Cloud-init customdata for nodes encoded in base64'
   computeNodesCount: 
     Type: Number
     Default: 2
@@ -342,6 +345,7 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      PrivateIpAddress: 10.10.0.11
       Tags:
         - 
           Key: "project"
@@ -376,7 +380,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatagw
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -447,7 +451,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -500,7 +504,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -555,7 +559,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -610,7 +614,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -665,7 +669,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -720,7 +724,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -775,7 +779,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -830,7 +834,7 @@ Resources:
         -
           NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
           DeviceIndex: 0
-      UserData: !Ref customdata
+      UserData: !Ref customdatanode
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -63,13 +63,6 @@ Resources:
     Properties:
       InternetGatewayId: !Ref flightcloudclusterinternetgateway
       VpcId: !Ref flightcloudclusternetwork
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   flightcloudclusterroutetable:
     Type: AWS::EC2::RouteTable
@@ -198,7 +191,7 @@ Resources:
       VPCs:
       - VPCId: !Ref flightcloudclusternetwork
         VPCRegion: !Ref 'AWS::Region'
-      Tags:
+      HostedZoneTags:
         - 
           Key: "project"
           Value: !Ref clustername

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -38,22 +38,51 @@ Resources:
       CidrBlock: 10.10.0.0/16
       EnableDnsSupport: true
       EnableDnsHostnames: true
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusterinternetgateway:
     Type: AWS::EC2::InternetGateway
     DependsOn: flightcloudclusternetwork
+    Properties:
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusterinternetgatewayattachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       InternetGatewayId: !Ref flightcloudclusterinternetgateway
       VpcId: !Ref flightcloudclusternetwork
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusterroutetable:
     Type: AWS::EC2::RouteTable
     DependsOn: flightcloudclusterinternetgatewayattachment
     Properties:
       VpcId: !Ref flightcloudclusternetwork
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusternetwork1:
     Type: AWS::EC2::Subnet
@@ -63,12 +92,26 @@ Resources:
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusternetwork1subnetroutetableassocation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       SubnetId: !Ref flightcloudclusternetwork1
       RouteTableId: !Ref flightcloudclusterroutetable
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusterrouteinternetgateway:
     Type: AWS::EC2::Route
@@ -77,6 +120,13 @@ Resources:
       RouteTableId: !Ref flightcloudclusterroutetable
       DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref flightcloudclusterinternetgateway
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclustersecuritygroup:
     Type: AWS::EC2::SecurityGroup
@@ -128,169 +178,246 @@ Resources:
           ToPort: 65535
           CidrIp: '0.0.0.0/0'
           Description: 'Allow outbound internet access'
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusterprivatedns:
-      Type: AWS::Route53::HostedZone
-      DependsOn: flightcloudclusternetwork
-      Properties:
-        HostedZoneConfig:
-          Comment: "Private DNS for a flightcloudcluster"
-        Name: !Sub
-          - "pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        VPCs:
-        - VPCId: !Ref flightcloudclusternetwork
-          VPCRegion: !Ref 'AWS::Region'
+    Type: AWS::Route53::HostedZone
+    DependsOn: flightcloudclusternetwork
+    Properties:
+      HostedZoneConfig:
+        Comment: "Private DNS for a flightcloudcluster"
+      Name: !Sub
+        - "pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      VPCs:
+      - VPCId: !Ref flightcloudclusternetwork
+        VPCRegion: !Ref 'AWS::Region'
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsgateway1:
-      Type: AWS::Route53::RecordSet
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for gateway1
-        Name: !Sub
-          - "gateway1.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclustergateway1.PrivateIp
+    Type: AWS::Route53::RecordSet
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for gateway1
+      Name: !Sub
+        - "gateway1.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclustergateway1.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode01:
-      Type: AWS::Route53::RecordSet
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node01
-        Name: !Sub
-          - "node01.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
+    Type: AWS::Route53::RecordSet
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node01
+      Name: !Sub
+        - "node01.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
         - !GetAtt flightcloudclusternode01.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode02:
-      Type: AWS::Route53::RecordSet
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node02
-        Name: !Sub
-          - "node02.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode02.PrivateIp
+    Type: AWS::Route53::RecordSet
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node02
+      Name: !Sub
+        - "node02.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode02.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode03:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode03
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node03
-        Name: !Sub
-          - "node03.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode03.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode03
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node03
+      Name: !Sub
+        - "node03.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode03.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode04:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode04
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node04
-        Name: !Sub
-          - "node04.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode04.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode04
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node04
+      Name: !Sub
+        - "node04.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode04.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode05:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode05
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node05
-        Name: !Sub
-          - "node05.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode05.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode05
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node05
+      Name: !Sub
+        - "node05.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode05.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode06:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode06
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node06
-        Name: !Sub
-          - "node06.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode06.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode06
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node06
+      Name: !Sub
+        - "node06.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode06.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode07:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode07
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node07
-        Name: !Sub
-          - "node07.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode07.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode07
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node07
+      Name: !Sub
+        - "node07.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode07.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   dnsnode08:
-      Type: AWS::Route53::RecordSet
-      Condition: CreateNode08
-      DependsOn: flightcloudclusterprivatedns
-      Properties:
-        HostedZoneName: !Sub
-          - "pri.${cn}.cluster.local."
-          - { cn: !Ref clustername }
-        Comment: Entry for node08
-        Name: !Sub
-          - "node08.pri.${cn}.cluster.local"
-          - { cn: !Ref clustername }
-        Type: A
-        TTL: '900'
-        ResourceRecords:
-        - !GetAtt flightcloudclusternode08.PrivateIp
+    Type: AWS::Route53::RecordSet
+    Condition: CreateNode08
+    DependsOn: flightcloudclusterprivatedns
+    Properties:
+      HostedZoneName: !Sub
+        - "pri.${cn}.cluster.local."
+        - { cn: !Ref clustername }
+      Comment: Entry for node08
+      Name: !Sub
+        - "node08.pri.${cn}.cluster.local"
+        - { cn: !Ref clustername }
+      Type: A
+      TTL: '900'
+      ResourceRecords:
+      - !GetAtt flightcloudclusternode08.PrivateIp
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclustergateway1network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -299,6 +426,13 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclustergateway1:
     Type: AWS::EC2::Instance
@@ -310,6 +444,12 @@ Resources:
           Value: !Sub
            - "${cn}_gateway1"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -331,12 +471,26 @@ Resources:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclustergateway1pubIPassociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
       NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
       AllocationId: !GetAtt flightcloudclustergateway1pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "core"
+          Value: "true"
 
   flightcloudclusternode01network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -345,6 +499,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode01:
     Type: AWS::EC2::Instance
@@ -356,6 +520,15 @@ Resources:
           Value: !Sub
            - "${cn}_node01"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -377,12 +550,32 @@ Resources:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode01pubIPassociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
       AllocationId: !GetAtt flightcloudclusternode01pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode02network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -391,6 +584,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode02:
     Type: AWS::EC2::Instance
@@ -402,6 +605,15 @@ Resources:
           Value: !Sub
            - "${cn}_node02"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -423,12 +635,32 @@ Resources:
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode02pubIPassociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
       AllocationId: !GetAtt flightcloudclusternode02pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode03network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -438,6 +670,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode03:
     Type: AWS::EC2::Instance
@@ -450,6 +692,15 @@ Resources:
           Value: !Sub
            - "${cn}_node03"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -472,6 +723,16 @@ Resources:
     Condition: CreateNode03
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode03pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -479,6 +740,16 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
       AllocationId: !GetAtt flightcloudclusternode03pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode04network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -488,6 +759,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode04:
     Type: AWS::EC2::Instance
@@ -500,6 +781,15 @@ Resources:
           Value: !Sub
            - "${cn}_node04"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -522,6 +812,16 @@ Resources:
     Condition: CreateNode04
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode04pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -529,6 +829,16 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
       AllocationId: !GetAtt flightcloudclusternode04pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode05network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -538,6 +848,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode05:
     Type: AWS::EC2::Instance
@@ -550,6 +870,15 @@ Resources:
           Value: !Sub
            - "${cn}_node05"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -572,6 +901,16 @@ Resources:
     Condition: CreateNode05
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode05pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -579,6 +918,16 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
       AllocationId: !GetAtt flightcloudclusternode05pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode06network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -588,6 +937,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode06:
     Type: AWS::EC2::Instance
@@ -600,6 +959,15 @@ Resources:
           Value: !Sub
            - "${cn}_node06"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -622,6 +990,16 @@ Resources:
     Condition: CreateNode06
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode06pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -629,6 +1007,16 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
       AllocationId: !GetAtt flightcloudclusternode06pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode07network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -638,6 +1026,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode07:
     Type: AWS::EC2::Instance
@@ -650,6 +1048,15 @@ Resources:
           Value: !Sub
            - "${cn}_node07"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -672,6 +1079,16 @@ Resources:
     Condition: CreateNode07
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode07pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -679,6 +1096,16 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
       AllocationId: !GetAtt flightcloudclusternode07pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode08network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -688,6 +1115,16 @@ Resources:
       GroupSet:
         - !Ref flightcloudclustersecuritygroup
       SubnetId: !Ref flightcloudclusternetwork1
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode08:
     Type: AWS::EC2::Instance
@@ -700,6 +1137,15 @@ Resources:
           Value: !Sub
            - "${cn}_node08"
            - { cn: !Ref clustername }
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
       AvailabilityZone: !Select
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -722,6 +1168,16 @@ Resources:
     Condition: CreateNode08
     Properties:
       Domain: vpc
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 
   flightcloudclusternode08pubIPassociation:
     Type: AWS::EC2::EIPAssociation
@@ -729,4 +1185,14 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
       AllocationId: !GetAtt flightcloudclusternode08pubIP.AllocationId
+      Tags:
+        - 
+          Key: "project"
+          Value: !Ref clustername
+        - 
+          Key: "compute"
+          Value: "true"
+        -
+          Key: "compute_group"
+          Value: "default"
 

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -477,13 +477,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
       AllocationId: !GetAtt flightcloudclustergateway1pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   flightcloudclusternode01network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -559,16 +552,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
       AllocationId: !GetAtt flightcloudclusternode01pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode02network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -644,16 +627,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
       AllocationId: !GetAtt flightcloudclusternode02pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode03network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -733,16 +706,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
       AllocationId: !GetAtt flightcloudclusternode03pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode04network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -822,16 +785,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
       AllocationId: !GetAtt flightcloudclusternode04pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode05network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -911,16 +864,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
       AllocationId: !GetAtt flightcloudclusternode05pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode06network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -1000,16 +943,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
       AllocationId: !GetAtt flightcloudclusternode06pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode07network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -1089,16 +1022,6 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
       AllocationId: !GetAtt flightcloudclusternode07pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 
   flightcloudclusternode08network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -1178,14 +1101,4 @@ Resources:
     Properties:
       NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
       AllocationId: !GetAtt flightcloudclusternode08pubIP.AllocationId
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
 

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -9,20 +9,20 @@ Parameters:
     Description: 'Name of the cluster'
   customdatagw:
     Type: String
-    Description: 'Cloud-init customdata for gateway encoded in base64'
+    Description: 'Cloud-init customdata for chead encoded in base64'
   customdatanode:
     Type: String
-    Description: 'Cloud-init customdata for nodes encoded in base64'
+    Description: 'Cloud-init customdata for cnodes encoded in base64'
   computeNodesCount: 
     Type: Number
     Default: 2
     MinValue: 2
     MaxValue: 8
     Description: 'Number of compute nodes to include in cluster'
-  gatewayinstancetype:
+  cheadinstancetype:
     Type: String
     Default: 't3.small'
-    Description: 'Instance type to be used for the gateway node'
+    Description: 'Instance type to be used for the chead node'
   computeinstancetype:
     Type: String
     Default: 't3.small'
@@ -188,23 +188,23 @@ Resources:
           Key: "core"
           Value: "true"
 
-  dnsgateway1:
+  dnschead1:
     Type: AWS::Route53::RecordSet
     DependsOn: flightcloudclusterprivatedns
     Properties:
       HostedZoneName: !Sub
         - "pri.${cn}.cluster.local."
         - { cn: !Ref clustername }
-      Comment: Entry for gateway1
+      Comment: Entry for chead1
       Name: !Sub
-        - "gateway1.pri.${cn}.cluster.local"
+        - "chead1.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclustergateway1.PrivateIp
+      - !GetAtt chead1.PrivateIp
 
-  dnsnode01:
+  dnscnode01:
     Type: AWS::Route53::RecordSet
     DependsOn: flightcloudclusterprivatedns
     Properties:
@@ -213,14 +213,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node01
       Name: !Sub
-        - "node01.pri.${cn}.cluster.local"
+        - "cnode01.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-        - !GetAtt flightcloudclusternode01.PrivateIp
+        - !GetAtt cnode01.PrivateIp
 
-  dnsnode02:
+  dnscnode02:
     Type: AWS::Route53::RecordSet
     DependsOn: flightcloudclusterprivatedns
     Properties:
@@ -229,14 +229,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node02
       Name: !Sub
-        - "node02.pri.${cn}.cluster.local"
+        - "cnode02.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode02.PrivateIp
+      - !GetAtt cnode02.PrivateIp
 
-  dnsnode03:
+  dnscnode03:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode03
     DependsOn: flightcloudclusterprivatedns
@@ -246,14 +246,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node03
       Name: !Sub
-        - "node03.pri.${cn}.cluster.local"
+        - "cnode03.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode03.PrivateIp
+      - !GetAtt cnode03.PrivateIp
 
-  dnsnode04:
+  dnscnode04:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode04
     DependsOn: flightcloudclusterprivatedns
@@ -263,14 +263,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node04
       Name: !Sub
-        - "node04.pri.${cn}.cluster.local"
+        - "cnode04.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode04.PrivateIp
+      - !GetAtt cnode04.PrivateIp
 
-  dnsnode05:
+  dnscnode05:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode05
     DependsOn: flightcloudclusterprivatedns
@@ -280,14 +280,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node05
       Name: !Sub
-        - "node05.pri.${cn}.cluster.local"
+        - "cnode05.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode05.PrivateIp
+      - !GetAtt cnode05.PrivateIp
 
-  dnsnode06:
+  dnscnode06:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode06
     DependsOn: flightcloudclusterprivatedns
@@ -297,14 +297,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node06
       Name: !Sub
-        - "node06.pri.${cn}.cluster.local"
+        - "cnode06.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode06.PrivateIp
+      - !GetAtt cnode06.PrivateIp
 
-  dnsnode07:
+  dnscnode07:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode07
     DependsOn: flightcloudclusterprivatedns
@@ -314,14 +314,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node07
       Name: !Sub
-        - "node07.pri.${cn}.cluster.local"
+        - "cnode07.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode07.PrivateIp
+      - !GetAtt cnode07.PrivateIp
 
-  dnsnode08:
+  dnscnode08:
     Type: AWS::Route53::RecordSet
     Condition: CreateNode08
     DependsOn: flightcloudclusterprivatedns
@@ -331,14 +331,14 @@ Resources:
         - { cn: !Ref clustername }
       Comment: Entry for node08
       Name: !Sub
-        - "node08.pri.${cn}.cluster.local"
+        - "cnode08.pri.${cn}.cluster.local"
         - { cn: !Ref clustername }
       Type: A
       TTL: '900'
       ResourceRecords:
-      - !GetAtt flightcloudclusternode08.PrivateIp
+      - !GetAtt cnode08.PrivateIp
 
-  flightcloudclustergateway1network1interface:
+  chead1network1interface:
     Type: AWS::EC2::NetworkInterface
     Properties:
       SourceDestCheck: false
@@ -354,15 +354,15 @@ Resources:
           Key: "core"
           Value: "true"
 
-  flightcloudclustergateway1:
+  chead1:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclustergateway1pubIPassociation
+    DependsOn: chead1pubIPassociation
     Properties:
       Tags:
         -
           Key: "Name"
           Value: !Sub
-           - "${cn}_gateway1"
+           - "${cn}_chead1"
            - { cn: !Ref clustername }
         - 
           Key: "project"
@@ -374,11 +374,11 @@ Resources:
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
       ImageId: !Ref sourceimage
-      InstanceType: !Ref gatewayinstancetype
+      InstanceType: !Ref cheadinstancetype
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
+          NetworkInterfaceId: !Ref chead1network1interface
           DeviceIndex: 0
       UserData: !Ref customdatagw
       BlockDeviceMappings:
@@ -387,7 +387,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclustergateway1pubIP: 
+  chead1pubIP: 
     Type: AWS::EC2::EIP
     Properties:
       Domain: vpc
@@ -399,13 +399,13 @@ Resources:
           Key: "core"
           Value: "true"
 
-  flightcloudclustergateway1pubIPassociation:
+  chead1pubIPassociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
-      NetworkInterfaceId: !Ref flightcloudclustergateway1network1interface
-      AllocationId: !GetAtt flightcloudclustergateway1pubIP.AllocationId
+      NetworkInterfaceId: !Ref chead1network1interface
+      AllocationId: !GetAtt chead1pubIP.AllocationId
 
-  flightcloudclusternode01network1interface:
+  cnode01network1interface:
     Type: AWS::EC2::NetworkInterface
     Properties:
       SourceDestCheck: false
@@ -423,7 +423,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode01:
+  cnode01:
     Type: AWS::EC2::Instance
     Properties:
       Tags:
@@ -449,7 +449,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
+          NetworkInterfaceId: !Ref cnode01network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -458,7 +458,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode02network1interface:
+  cnode02network1interface:
     Type: AWS::EC2::NetworkInterface
     Properties:
       SourceDestCheck: false
@@ -476,7 +476,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode02:
+  cnode02:
     Type: AWS::EC2::Instance
     Properties:
       Tags:
@@ -502,7 +502,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
+          NetworkInterfaceId: !Ref cnode02network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -511,7 +511,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode03network1interface:
+  cnode03network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode03
     Properties:
@@ -530,7 +530,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode03:
+  cnode03:
     Type: AWS::EC2::Instance
     Condition: CreateNode03
     Properties:
@@ -557,7 +557,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
+          NetworkInterfaceId: !Ref cnode03network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -566,7 +566,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode04network1interface:
+  cnode04network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode04
     Properties:
@@ -585,7 +585,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode04:
+  cnode04:
     Type: AWS::EC2::Instance
     Condition: CreateNode04
     Properties:
@@ -612,7 +612,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
+          NetworkInterfaceId: !Ref cnode04network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -621,7 +621,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode05network1interface:
+  cnode05network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode05
     Properties:
@@ -640,7 +640,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode05:
+  cnode05:
     Type: AWS::EC2::Instance
     Condition: CreateNode05
     Properties:
@@ -667,7 +667,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
+          NetworkInterfaceId: !Ref cnode05network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -676,7 +676,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode06network1interface:
+  cnode06network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode06
     Properties:
@@ -695,7 +695,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode06:
+  cnode06:
     Type: AWS::EC2::Instance
     Condition: CreateNode06
     Properties:
@@ -722,7 +722,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
+          NetworkInterfaceId: !Ref cnode06network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -731,7 +731,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode07network1interface:
+  cnode07network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode07
     Properties:
@@ -750,7 +750,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode07:
+  cnode07:
     Type: AWS::EC2::Instance
     Condition: CreateNode07
     Properties:
@@ -777,7 +777,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
+          NetworkInterfaceId: !Ref cnode07network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:
@@ -786,7 +786,7 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode08network1interface:
+  cnode08network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode08
     Properties:
@@ -805,7 +805,7 @@ Resources:
           Key: "compute_group"
           Value: "default"
 
-  flightcloudclusternode08:
+  cnode08:
     Type: AWS::EC2::Instance
     Condition: CreateNode08
     Properties:
@@ -832,7 +832,7 @@ Resources:
       Monitoring: true
       NetworkInterfaces:
         -
-          NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
+          NetworkInterfaceId: !Ref cnode08network1interface
           DeviceIndex: 0
       UserData: !Ref customdatanode
       BlockDeviceMappings:

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -421,7 +421,6 @@ Resources:
 
   flightcloudclusternode01:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode01pubIPassociation
     Properties:
       Tags:
         -
@@ -475,7 +474,6 @@ Resources:
 
   flightcloudclusternode02:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode02pubIPassociation
     Properties:
       Tags:
         -
@@ -530,7 +528,6 @@ Resources:
 
   flightcloudclusternode03:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode03pubIPassociation
     Condition: CreateNode03
     Properties:
       Tags:
@@ -586,7 +583,6 @@ Resources:
 
   flightcloudclusternode04:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode04pubIPassociation
     Condition: CreateNode04
     Properties:
       Tags:
@@ -642,7 +638,6 @@ Resources:
 
   flightcloudclusternode05:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode05pubIPassociation
     Condition: CreateNode05
     Properties:
       Tags:
@@ -698,7 +693,6 @@ Resources:
 
   flightcloudclusternode06:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode06pubIPassociation
     Condition: CreateNode06
     Properties:
       Tags:
@@ -754,7 +748,6 @@ Resources:
 
   flightcloudclusternode07:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode07pubIPassociation
     Condition: CreateNode07
     Properties:
       Tags:
@@ -810,7 +803,6 @@ Resources:
 
   flightcloudclusternode08:
     Type: AWS::EC2::Instance
-    DependsOn: flightcloudclusternode08pubIPassociation
     Condition: CreateNode08
     Properties:
       Tags:

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -200,13 +200,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclustergateway1.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode01:
     Type: AWS::Route53::RecordSet
@@ -223,13 +216,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
         - !GetAtt flightcloudclusternode01.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode02:
     Type: AWS::Route53::RecordSet
@@ -246,13 +232,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode02.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode03:
     Type: AWS::Route53::RecordSet
@@ -270,13 +249,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode03.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode04:
     Type: AWS::Route53::RecordSet
@@ -294,13 +266,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode04.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode05:
     Type: AWS::Route53::RecordSet
@@ -318,13 +283,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode05.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode06:
     Type: AWS::Route53::RecordSet
@@ -342,13 +300,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode06.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode07:
     Type: AWS::Route53::RecordSet
@@ -366,13 +317,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode07.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   dnsnode08:
     Type: AWS::Route53::RecordSet
@@ -390,13 +334,6 @@ Resources:
       TTL: '900'
       ResourceRecords:
       - !GetAtt flightcloudclusternode08.PrivateIp
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "core"
-          Value: "true"
 
   flightcloudclustergateway1network1interface:
     Type: AWS::EC2::NetworkInterface

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -455,27 +455,6 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode01pubIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode01pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode01network1interface
-      AllocationId: !GetAtt flightcloudclusternode01pubIP.AllocationId
-
   flightcloudclusternode02network1interface:
     Type: AWS::EC2::NetworkInterface
     Properties:
@@ -529,27 +508,6 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
-
-  flightcloudclusternode02pubIP:
-    Type: AWS::EC2::EIP
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode02pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode02network1interface
-      AllocationId: !GetAtt flightcloudclusternode02pubIP.AllocationId
 
   flightcloudclusternode03network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -607,29 +565,6 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode03pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode03
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode03pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode03
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode03network1interface
-      AllocationId: !GetAtt flightcloudclusternode03pubIP.AllocationId
-
   flightcloudclusternode04network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode04
@@ -685,29 +620,6 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
-
-  flightcloudclusternode04pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode04
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode04pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode04
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode04network1interface
-      AllocationId: !GetAtt flightcloudclusternode04pubIP.AllocationId
 
   flightcloudclusternode05network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -765,29 +677,6 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode05pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode05
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode05pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode05
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode05network1interface
-      AllocationId: !GetAtt flightcloudclusternode05pubIP.AllocationId
-
   flightcloudclusternode06network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode06
@@ -843,29 +732,6 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
-
-  flightcloudclusternode06pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode06
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode06pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode06
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode06network1interface
-      AllocationId: !GetAtt flightcloudclusternode06pubIP.AllocationId
 
   flightcloudclusternode07network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -923,29 +789,6 @@ Resources:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
 
-  flightcloudclusternode07pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode07
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode07pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode07
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode07network1interface
-      AllocationId: !GetAtt flightcloudclusternode07pubIP.AllocationId
-
   flightcloudclusternode08network1interface:
     Type: AWS::EC2::NetworkInterface
     Condition: CreateNode08
@@ -1001,27 +844,4 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
-
-  flightcloudclusternode08pubIP:
-    Type: AWS::EC2::EIP
-    Condition: CreateNode08
-    Properties:
-      Domain: vpc
-      Tags:
-        - 
-          Key: "project"
-          Value: !Ref clustername
-        - 
-          Key: "compute"
-          Value: "true"
-        -
-          Key: "compute_group"
-          Value: "default"
-
-  flightcloudclusternode08pubIPassociation:
-    Type: AWS::EC2::EIPAssociation
-    Condition: CreateNode08
-    Properties:
-      NetworkInterfaceId: !Ref flightcloudclusternode08network1interface
-      AllocationId: !GetAtt flightcloudclusternode08pubIP.AllocationId
 

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -17,20 +17,20 @@
       "customdatagw": {
           "type": "string",
           "metadata": {
-              "description": "Cloud-init customdata for gateway encoded in base64"
+              "description": "Cloud-init customdata for chead encoded in base64"
           }
       },
       "customdatanode": {
           "type": "string",
           "metadata": {
-              "description": "Cloud-init customdata for nodes encoded in base64"
+              "description": "Cloud-init customdata for cnodes encoded in base64"
           }
       },
-      "gatewayinstancetype": {
+      "cheadinstancetype": {
           "type": "string",
           "defaultValue": "Standard_DS1_v2",
           "metadata": {
-              "description": "Instance type to use for gateway node"
+              "description": "Instance type to use for chead node"
           }
       },
       "computeinstancetype": {
@@ -145,7 +145,7 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "flightcloudclustergateway1pubIP",
+      "name": "chead1pubIP",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
       "tags": {
@@ -156,13 +156,13 @@
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 30,
         "dnsSettings": {
-          "domainNameLabel": "[concat('gateway1-', parameters('clustername'))]"
+          "domainNameLabel": "[concat('chead1-', parameters('clustername'))]"
         }
       }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "flightcloudclustergateway1network1interface",
+      "name": "chead1network1interface",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
       "tags": {
@@ -171,12 +171,12 @@
       },
       "properties": {
         "ipConfigurations": [{
-          "name": "flightcloudclustergateway1network1ip",
+          "name": "chead1network1ip",
           "properties": {
             "privateIPAllocationMethod": "Static",
             "privateIPAddress": "10.10.0.11",
             "publicIPAddress": {
-              "id": "[resourceId('Microsoft.Network/publicIpAddresses', 'flightcloudclustergateway1pubIP')]"
+              "id": "[resourceId('Microsoft.Network/publicIpAddresses', 'chead1pubIP')]"
             },
             "subnet": {
               "id": "[variables('subnet1Ref')]"
@@ -188,12 +188,12 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIpAddresses', 'flightcloudclustergateway1pubIP')]"
+        "[resourceId('Microsoft.Network/publicIpAddresses', 'chead1pubIP')]"
       ]
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "flightcloudclustergateway1",
+      "name": "chead1",
       "apiVersion": "2016-04-30-preview",
       "location": "[resourceGroup().location]",
       "tags": {
@@ -202,7 +202,7 @@
       },
       "properties": {
         "hardwareProfile": {
-              "vmSize": "[parameters('gatewayinstancetype')]"
+              "vmSize": "[parameters('cheadinstancetype')]"
             },
         "storageProfile": {
           "osDisk": {
@@ -216,7 +216,7 @@
           }
         },
         "osProfile": {
-          "computerName": "[concat('gateway1.pri.', parameters('clustername'), '.cluster.local')]",
+          "computerName": "[concat('chead1.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
           "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdatagw')]",
@@ -235,7 +235,7 @@
         "networkProfile": {
           "networkInterfaces": [
           {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', 'flightcloudclustergateway1network1interface')]",
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', 'chead1network1interface')]",
                 "properties": {
                   "primary": true
                 }
@@ -244,12 +244,12 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/networkInterfaces', 'flightcloudclustergateway1network1interface')]"
+        "[resourceId('Microsoft.Network/networkInterfaces', 'chead1network1interface')]"
       ]
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat('flightcloudclusternode0', copyindex(1), 'network1interface')]",
+      "name": "[concat('cnode0', copyindex(1), 'network1interface')]",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
       "copy": {
@@ -263,7 +263,7 @@
       },
       "properties": {
         "ipConfigurations": [{
-          "name": "[concat('flightcloudclusternode0', copyindex(1), 'network1ip')]",
+          "name": "[concat('cnode0', copyindex(1), 'network1ip')]",
           "properties": {
             "privateIPAllocationMethod": "Dynamic",
             "subnet": {
@@ -278,7 +278,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat('flightcloudclusternode0', copyindex(1))]",
+      "name": "[concat('cnode0', copyindex(1))]",
       "apiVersion": "2016-04-30-preview",
       "location": "[resourceGroup().location]",
       "copy": {
@@ -306,7 +306,7 @@
           }
         },
           "osProfile": {
-          "computerName": "[concat('node0', copyindex(1), '.pri.', parameters('clustername'), '.cluster.local')]",
+          "computerName": "[concat('cnode0', copyindex(1), '.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
           "adminPassword": "OpenFlightPlaceholderPassword",
           "customdata": "[parameters('customdatanode')]",
@@ -325,7 +325,7 @@
         "networkProfile": {
           "networkInterfaces": [
           {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('flightcloudclusternode0', copyindex(1), 'network1interface'))]",
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('cnode0', copyindex(1), 'network1interface'))]",
                 "properties": {
                   "primary": true
                 }

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -66,7 +66,11 @@
               "addressPrefix": "10.10.0.0/19"
             }
           }
-        ]
+        ],
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "core": "true"
+        }
       }
     },
     {
@@ -126,8 +130,12 @@
              "priority": 1010,
              "direction": "Inbound"
            }
-         }]
-       }
+         }],
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "core": "true"
+        }
+      }
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
@@ -139,6 +147,10 @@
         "idleTimeoutInMinutes": 30,
         "dnsSettings": {
           "domainNameLabel": "[concat('gateway1-', parameters('clustername'))]"
+        },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "core": "true"
         }
       }
     },
@@ -162,6 +174,10 @@
         }],
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'flightcloudclustersecuritygroup')]"
+        },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "core": "true"
         }
       },
       "dependsOn": [
@@ -214,6 +230,10 @@
                 }
           }
           ]
+        },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "core": "true"
         }
       },
       "dependsOn": [
@@ -234,6 +254,11 @@
         "idleTimeoutInMinutes": 30,
         "dnsSettings": {
           "domainNameLabel": "[concat('node0', copyindex(1), '-', parameters('clustername'))]"
+        },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "compute": "true",
+            "compute_group": "default"
         }
       }
     },
@@ -261,6 +286,11 @@
         }],
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'flightcloudclustersecuritygroup')]"
+        },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "compute": "true",
+            "compute_group": "default"
         }
       },
       "dependsOn": [
@@ -317,7 +347,12 @@
                 }
           }
           ]
-      }
+      },
+        "tags": {
+            "project": "[parameters('clustername')]",
+            "compute": "true",
+            "compute_group": "default"
+        }
     },
     "dependsOn": [
         "nicLoop"

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -248,28 +248,6 @@
       ]
     },
     {
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat('flightcloudclusternode0', copyindex(1), 'pubIP')]",
-      "apiVersion": "2017-03-01",
-      "location": "[resourceGroup().location]",
-      "copy": {
-          "name": "pubLoop",
-          "count": "[parameters('computeNodesCount')]"
-      },
-      "tags": {
-          "project": "[parameters('clustername')]",
-          "compute": "true",
-          "compute_group": "default"
-      },
-      "properties": {
-        "publicIPAllocationMethod": "Static",
-        "idleTimeoutInMinutes": 30,
-        "dnsSettings": {
-          "domainNameLabel": "[concat('node0', copyindex(1), '-', parameters('clustername'))]"
-        }
-      }
-    },
-    {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat('flightcloudclusternode0', copyindex(1), 'network1interface')]",
       "apiVersion": "2017-03-01",
@@ -288,9 +266,6 @@
           "name": "[concat('flightcloudclusternode0', copyindex(1), 'network1ip')]",
           "properties": {
             "privateIPAllocationMethod": "Dynamic",
-            "publicIPAddress": {
-              "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat('flightcloudclusternode0', copyindex(1), 'pubIP'))]"
-            },
             "subnet": {
               "id": "[variables('subnet1Ref')]"
             }

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -53,6 +53,10 @@
       "name": "flightcloudclusternetwork",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "core": "true"
+      },
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -66,11 +70,7 @@
               "addressPrefix": "10.10.0.0/19"
             }
           }
-        ],
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "core": "true"
-        }
+        ]
       }
     },
     {
@@ -78,6 +78,10 @@
       "name": "flightcloudclustersecuritygroup",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "core": "true"
+      },
       "properties": {
         "securityRules": [{
            "name": "inbound-ssh",
@@ -130,11 +134,7 @@
              "priority": 1010,
              "direction": "Inbound"
            }
-         }],
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "core": "true"
-        }
+         }]
       }
     },
     {
@@ -142,15 +142,15 @@
       "name": "flightcloudclustergateway1pubIP",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "core": "true"
+      },
       "properties": {
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 30,
         "dnsSettings": {
           "domainNameLabel": "[concat('gateway1-', parameters('clustername'))]"
-        },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "core": "true"
         }
       }
     },
@@ -159,6 +159,10 @@
       "name": "flightcloudclustergateway1network1interface",
       "apiVersion": "2017-03-01",
       "location": "[resourceGroup().location]",
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "core": "true"
+      },
       "properties": {
         "ipConfigurations": [{
           "name": "flightcloudclustergateway1network1ip",
@@ -174,10 +178,6 @@
         }],
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'flightcloudclustersecuritygroup')]"
-        },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "core": "true"
         }
       },
       "dependsOn": [
@@ -189,6 +189,10 @@
       "name": "flightcloudclustergateway1",
       "apiVersion": "2016-04-30-preview",
       "location": "[resourceGroup().location]",
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "core": "true"
+      },
       "properties": {
         "hardwareProfile": {
               "vmSize": "[parameters('gatewayinstancetype')]"
@@ -230,10 +234,6 @@
                 }
           }
           ]
-        },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "core": "true"
         }
       },
       "dependsOn": [
@@ -249,16 +249,16 @@
           "name": "pubLoop",
           "count": "[parameters('computeNodesCount')]"
       },
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "compute": "true",
+          "compute_group": "default"
+      },
       "properties": {
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 30,
         "dnsSettings": {
           "domainNameLabel": "[concat('node0', copyindex(1), '-', parameters('clustername'))]"
-        },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "compute": "true",
-            "compute_group": "default"
         }
       }
     },
@@ -270,6 +270,11 @@
       "copy": {
           "name": "nicLoop",
           "count": "[parameters('computeNodesCount')]"
+      },
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "compute": "true",
+          "compute_group": "default"
       },
       "properties": {
         "ipConfigurations": [{
@@ -286,11 +291,6 @@
         }],
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'flightcloudclustersecuritygroup')]"
-        },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "compute": "true",
-            "compute_group": "default"
         }
       },
       "dependsOn": [
@@ -305,6 +305,11 @@
       "copy": {
           "name": "computeLoop",
           "count": "[parameters('computeNodesCount')]"
+      },
+      "tags": {
+          "project": "[parameters('clustername')]",
+          "compute": "true",
+          "compute_group": "default"
       },
       "properties": {
         "hardwareProfile": {
@@ -347,12 +352,7 @@
                 }
           }
           ]
-      },
-        "tags": {
-            "project": "[parameters('clustername')]",
-            "compute": "true",
-            "compute_group": "default"
-        }
+      }
     },
     "dependsOn": [
         "nicLoop"

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -274,10 +274,7 @@
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'flightcloudclustersecuritygroup')]"
         }
-      },
-      "dependsOn": [
-        "pubLoop"
-      ]
+      }
     },
     {
       "type": "Microsoft.Compute/virtualMachines",

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -14,10 +14,16 @@
               "description": "Name of the cluster"
           }
       },
-      "customdata": {
+      "customdatagw": {
           "type": "string",
           "metadata": {
-              "description": "Cloud-init customdata for all systems encoded in base64"
+              "description": "Cloud-init customdata for gateway encoded in base64"
+          }
+      },
+      "customdatanode": {
+          "type": "string",
+          "metadata": {
+              "description": "Cloud-init customdata for nodes encoded in base64"
           }
       },
       "gatewayinstancetype": {
@@ -167,7 +173,8 @@
         "ipConfigurations": [{
           "name": "flightcloudclustergateway1network1ip",
           "properties": {
-            "privateIPAllocationMethod": "Dynamic",
+            "privateIPAllocationMethod": "Static",
+            "privateIPAddress": "10.10.0.11",
             "publicIPAddress": {
               "id": "[resourceId('Microsoft.Network/publicIpAddresses', 'flightcloudclustergateway1pubIP')]"
             },
@@ -212,7 +219,7 @@
           "computerName": "[concat('gateway1.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
           "adminPassword": "OpenFlightPlaceholderPassword",
-          "customdata": "[parameters('customdata')]",
+          "customdata": "[parameters('customdatagw')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {
@@ -330,7 +337,7 @@
           "computerName": "[concat('node0', copyindex(1), '.pri.', parameters('clustername'), '.cluster.local')]",
           "adminUsername": "flight",
           "adminPassword": "OpenFlightPlaceholderPassword",
-          "customdata": "[parameters('customdata')]",
+          "customdata": "[parameters('customdatanode')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": true,
             "ssh": {


### PR DESCRIPTION
This PR:
- Adds the various tags for integration with Cloud Cost Reporter & Cloud Cost Visualiser
- Adds separate custom data for gateway and compute nodes (varying configuration now needed for network forwarding)
- Removes public IPs from compute nodes (reducing cost & resource usage)
- Configures network forwarding via the gateway for compute nodes (now they no longer have pub IPs)
- Tweaks ansible configuration to use SSH jumps to configure nodes via gateway
- Sets a static private IP (`10.10.0.11`) for the gateway
- Renames gateway to chead and node to cnode