### PR TITLE
Various Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+settings.sh
+configs/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains scripts for the R&D setup of OpenFlight Compute.
 
 To support FQDNs for a custom domain on Azure & AWS a little bit of preparation is needed. The instructions below explain how to point a subdomain hosted externally to both platforms at the two platforms in order to allow for custom FQDNS.
 
-The subdomains need to be set for both the `AWS_DOMAIN` and `AZURE_DOMAIN` application-wide settings in `settings.sh`. Additionally the `AZURE_DOMAIN_RG` needs to be set to the resource group where the DNS Zone exists. (_Note: these settings can be overridden on a per-config basis_)
+The subdomains need to be set for both the `AWS_DOMAIN` and `AZURE_DOMAIN` application-wide settings in `settings.sh`. Additionally the `AWS_DOMAIN_ID` needs to be set to the ID of the Route53 zone and the `AZURE_DOMAIN_RG` needs to be set to the resource group where the DNS Zone exists. (_Note: these settings can be overridden on a per-config basis_)
 
 ### AWS
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently, this is being developed and tested on Azure.
 6. Check/update the application settings
 
    ```
-   vim settings.sh
+   cp settings.sh.example settings.sh
    ```
 
 ## Create a Cluster

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository contains scripts for the R&D setup of OpenFlight Compute.
 
+## Cloud DNS Preparation
+
+To support FQDNs for a custom domain on Azure & AWS a little bit of preparation is needed. The instructions below explain how to point a subdomain hosted externally to both platforms at the two platforms in order to allow for custom FQDNS.
+
+The subdomains need to be set for both the `AWS_DOMAIN` and `AZURE_DOMAIN` application-wide settings in `settings.sh`. Additionally the `AZURE_DOMAIN_RG` needs to be set to the resource group where the DNS Zone exists. (_Note: these settings can be overridden on a per-config basis_)
+
+### AWS
+
+- Create public hosted zone in Route53 for the subdomain (e.g. `zone1.clusters.openflighthpc.org`)
+- Create an NS record for the subdomain in the external DNS provider pointing to the Route53 nameservers 
+
+### Azure
+
+- Create public hosted zone in DNS Zones for the subdomain (e.g. `zone2.clusters.openflighthpc.org`)
+- Create an NS record for the subdomain in the external DNS provider pointing to the Azure DNS Zone nameservers
+
 ## Configure Environment
 
 Currently, this is being developed and tested on Azure.

--- a/build-cluster.sh
+++ b/build-cluster.sh
@@ -292,10 +292,15 @@ function run_ansible() {
         flightenv_bootstrap_var="flightenv_bootstrap=true"
     fi
 
+    # Determine if Alces branding to be setup
+    if [ "$ALCESBRANDING" = "true" ] ; then
+        flightenv_alces_branding="alces=true"
+    fi
+
     # Run ansible playbook
     cd $ANSIBLE_PLAYBOOK_DIR
     export ANSIBLE_HOST_KEY_CHECKING=false
-    ARGS="cluster_name=$CLUSTERNAMEARG compute_ip_range='10.10.0.0/255.255.0.0' shared_ssh_key='$SSH_PUB_KEY' flightweb_fqdn='$CHEADFQDN' $flightenv_dev_var $flightenv_bootstrap_var"
+    ARGS="cluster_name=$CLUSTERNAMEARG compute_ip_range='10.10.0.0/255.255.0.0' shared_ssh_key='$SSH_PUB_KEY' flightweb_fqdn='$CHEADFQDN' $flightenv_dev_var $flightenv_bootstrap_var $flightenv_alces_branding"
     echo "$(date +'%Y-%m-%d %H-%M-%S') | $CLUSTERNAME | Start Ansible | ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook -i /opt/flight/clusters/$CLUSTERNAME --extra-vars \"$ARGS\" openflight.yml" |tee -a $LOG
     ansible-playbook -i /opt/flight/clusters/$CLUSTERNAME --extra-vars "$ARGS" openflight.yml
 }

--- a/configs/default.sh
+++ b/configs/default.sh
@@ -44,6 +44,11 @@ FLIGHTENVDEV=false
 # are installed before users login
 FLIGHTENVPREPARE=false
 
+# If true then the ansible-playbook will install 
+# packages to brand the user and web suite with
+# the Alces moosebird
+ALCESBRANDING=false
+
 #
 # Azure Configuration
 #

--- a/destroy-cluster.sh
+++ b/destroy-cluster.sh
@@ -7,6 +7,9 @@
 # Get directory of script for locating templates and config
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Source application variables
+source $DIR/settings.sh
+
 # Source variables
 if [ -z "${CONFIG}" ] ; then
     source $DIR/configs/default.sh
@@ -60,6 +63,7 @@ function check_cluster_azure {
 function destroy_cluster_azure {
     cluster=$1
     az group delete -y --name $cluster
+    az network dns record-set a delete --resource-group $AZURE_DOMAIN_RG --zone-name $AZURE_DOMAIN --name "chead1.$cluster" -y
 }
 
 function check_cluster_aws {

--- a/settings.sh
+++ b/settings.sh
@@ -5,3 +5,8 @@ ANSIBLE_PLAYBOOK_DIR=/root/openflight-ansible-playbook
 AZURE_TEMPLATE=templates/azure/cluster.json
 AWS_TEMPLATE=templates/aws/cluster.yaml
 
+# FQDN for platforms
+## See the README for more information on what these are and how to set them up
+AWS_DOMAIN=""
+AZURE_DOMAIN=""
+AZURE_DOMAIN_RG=""

--- a/settings.sh.example
+++ b/settings.sh.example
@@ -7,6 +7,7 @@ AWS_TEMPLATE=templates/aws/cluster.yaml
 
 # FQDN for platforms
 ## See the README for more information on what these are and how to set them up
-AWS_DOMAIN=""
-AZURE_DOMAIN=""
+AWS_DOMAIN="zone1.mydomain.com"
+AWS_DOMAIN_ID=""
+AZURE_DOMAIN="zone2.mydomain.com"
 AZURE_DOMAIN_RG=""

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -500,6 +500,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode02network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -553,6 +554,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode03network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -608,6 +610,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode04network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -663,6 +666,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode05network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -718,6 +722,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode06network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -773,6 +778,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode07network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -828,6 +834,7 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 
   cnode08network1interface:
     Type: AWS::EC2::NetworkInterface
@@ -883,4 +890,5 @@ Resources:
           Ebs:
             VolumeType: 'gp3'
             DeleteOnTermination: 'true'
+            VolumeSize: 12
 

--- a/templates/aws/cluster.yaml
+++ b/templates/aws/cluster.yaml
@@ -427,6 +427,7 @@ Resources:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeType: 'gp3'
+            VolumeSize: 32
             DeleteOnTermination: 'true'
 
   chead1pubIP:

--- a/templates/azure/cluster.json
+++ b/templates/azure/cluster.json
@@ -330,6 +330,7 @@
         "storageProfile": {
           "osDisk": {
             "createOption": "fromImage",
+            "DiskSizeGB": 12,
             "managedDisk": {
               "storageAccountType": "Premium_LRS"
             }


### PR DESCRIPTION
- Add support for creating DNS entries in various cloud providers which allows [openflighthpc/openflight-ansible-playbook](https://github.com/openflighthpc/openflight-ansible-playbook) to generate Let's Encrypt certificates for the Web Suite installation
    - The `destroy-cluster.sh` script also removes these DNS entries to ensure no mess is left around cloud services
    - There are global config variables for the required information (as outlined in the README) to ensure the correct entries are created
- Added flag for Alces Branding to instruct [openflighthpc/openflight-ansible-playbook](https://github.com/openflighthpc/openflight-ansible-playbook) to toggle branding if set to true
- The `settings.sh` file has been moved to `settings.sh.example` and a .gitignore has been added/updated to prevent git branches being spammed with config files and install-specific settings